### PR TITLE
Fix an issue with G3 on GRBL

### DIFF
--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -2629,8 +2629,9 @@ onAddGcode : function(addGcodeCallback, gcodeParts, eagleWidget, helpDesc){
                     if(z < that.depthOfDimensions)
                         z = that.depthOfDimensions;
                     g += "G1 Z" + z.toFixed(4) + "\n"; //V5.2QUICKFIX
-                    g += (dir==2)?"G2 I":"G3 I";
-                    g += gdiameter.toFixed(4) + "\n";
+                    g += (dir==2)?"G2":"G3";
+                    g += " X" + that.round(hole.X - gdiameter) + " Y" + that.round(hole.Y);
+                    g += " I" + gdiameter.toFixed(4) + "\n";
                 }
                 g += "G0 Z" + that.clearanceHeight + "\n";
             });

--- a/widget.js
+++ b/widget.js
@@ -2485,8 +2485,9 @@ onAddGcode : function(addGcodeCallback, gcodeParts, eagleWidget, helpDesc){
                     if(z < that.depthOfDimensions)
                         z = that.depthOfDimensions;
                     g += "G1 Z" + z.toFixed(4) + "\n"; //V5.2QUICKFIX
-                    g += (dir==2)?"G2 I":"G3 I";
-                    g += gdiameter.toFixed(4) + "\n";
+                    g += (dir==2)?"G2":"G3";
+                    g += " X" + that.round(hole.X - gdiameter) + " Y" + that.round(hole.Y);
+                    g += " I" + gdiameter.toFixed(4) + "\n";
                 }
                 g += "G0 Z" + that.clearanceHeight + "\n";
             });


### PR DESCRIPTION
GRBL throws error "Invalid gcode ID:26" when G3 line includes only IJ values without XY, this only affects holes milling, other G3 commands are generated with XY values.
Issue fixed by adding previous XY values to G3 commands.